### PR TITLE
show cancelled day order visually in list-food component

### DIFF
--- a/src/app/components/clients/order/inicio/inicio-order.component.html
+++ b/src/app/components/clients/order/inicio/inicio-order.component.html
@@ -62,17 +62,9 @@
         (selectedAddressEmit)="onChangeAddress($event)">
       </app-selected-address>
     </mat-step>
-    <mat-step label="¿Querés agregar algo más?">
-      <h4>Si querés, sumá productos extras a tu pedido (postres, ensaladas, etc.)</h4>
-      <app-order-products
-        [products]="availableProducts"
-        (productsSelected)="onProductsSelected($event)">
-      </app-order-products>
-    </mat-step>
     <mat-step label="Confirmación">
       <h4>Por último, confirmá tu pedido</h4>
       <app-confirmation [order]="order">
-
       </app-confirmation>
     </mat-step>
   </mat-stepper>

--- a/src/app/components/clients/order/inicio/inicio-order.component.ts
+++ b/src/app/components/clients/order/inicio/inicio-order.component.ts
@@ -460,14 +460,10 @@ export class InicioOrderComponent implements OnInit, OnExit {
         break;
       }
       case 3: {
-        this.onLoadProducts();
-        break;
-      }
-      case 4: {
         this.onGetTotal();
         break;
       }
-      case 5: {
+      case 4: {
         this.sendOrder();
         break;
       }

--- a/src/app/components/clients/order/list-food/list-food.component.css
+++ b/src/app/components/clients/order/list-food/list-food.component.css
@@ -73,6 +73,22 @@ h4 {
   background-color: #c700008d;
   color: rgb(55, 55, 55);
 }
+
+.cancelled-day-order {
+  opacity: 0.55;
+  background-color: #f0f0f0;
+}
+
+.cancelled-header {
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: 4px;
+}
+
+.cancelled-content {
+  text-decoration: line-through;
+  color: #888;
+}
 .active-order{
   background-color: #50b1ce96;
   color: rgb(55, 55, 55);

--- a/src/app/components/clients/order/list-food/list-food.component.css
+++ b/src/app/components/clients/order/list-food/list-food.component.css
@@ -86,8 +86,6 @@ h4 {
 }
 
 .cancelled-content {
-  text-decoration: line-through;
-  color: #888;
 }
 .active-order{
   background-color: #50b1ce96;

--- a/src/app/components/clients/order/list-food/list-food.component.html
+++ b/src/app/components/clients/order/list-food/list-food.component.html
@@ -2,14 +2,14 @@
   <div *ngFor="let day of daysOfMonth">
     <p class="day">{{ getDay(day)}} - {{ day | date: 'dd/MM' }}</p>
       <div *ngFor="let dayOrder of order.daysOrder">
-        <mat-card class="food-card" *ngIf="(dayOrder.dayFood.date | date:'dd/MM') == (day | date:'dd/MM')" [style]="{'border-right': '5px solid'+dayOrder.dayFood.category.color}">
-          <!-- <mat-card-subtitle>
+        <mat-card class="food-card" *ngIf="(dayOrder.dayFood.date | date:'dd/MM') == (day | date:'dd/MM')" [style]="{'border-right': '5px solid'+dayOrder.dayFood.category.color}" [class.cancelled-day-order]="!dayOrder.status">
+          <mat-card-subtitle *ngIf="!dayOrder.status" class="cancelled-header">
             <span class="spacer"></span>
             <mat-chip-list>
-                <mat-chip *ngIf="dayOrder.status == false" class="cancel-order">Cancelada</mat-chip>
-            </mat-chip-list>  
-          </mat-card-subtitle> -->
-          <mat-card-title-group>
+              <mat-chip class="cancel-order">Cancelada</mat-chip>
+            </mat-chip-list>
+          </mat-card-subtitle>
+          <mat-card-title-group [class.cancelled-content]="!dayOrder.status">
               <mat-card-subtitle>{{ getDay(day)}} - {{ day | date: 'dd/MM' }} ({{ dayOrder.dayFood.category.title }})</mat-card-subtitle>
               <mat-card-title><h4><span *ngIf="editAddress"> {{ dayOrder.cant }} X</span> {{ dayOrder.dayFood.food.title }}</h4></mat-card-title>
               <mat-card-subtitle class="descriptionSubtitle">{{ dayOrder.dayFood.food.description }}</mat-card-subtitle>

--- a/src/app/components/clients/order/order-products/order-products.component.html
+++ b/src/app/components/clients/order/order-products/order-products.component.html
@@ -10,7 +10,7 @@
         <mat-card-subtitle *ngIf="po.product.description">{{po.product.description}}</mat-card-subtitle>
       </mat-card-header>
 
-      <img mat-card-image *ngIf="po.product.urlImage" [src]="po.product.urlImage" [alt]="po.product.title">
+      <img mat-card-image *ngIf="po.product.urlImage" src="{{URLAPI}}{{po.product.urlImage}}" [alt]="po.product.title">
 
       <mat-card-content>
         <p class="price">${{po.product.price}}</p>

--- a/src/app/components/clients/order/order-products/order-products.component.ts
+++ b/src/app/components/clients/order/order-products/order-products.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { environment } from 'src/environments/environment';
 import { Product } from 'src/app/shared/models/Product';
 
 export interface ProductOrder {
@@ -13,6 +14,7 @@ export interface ProductOrder {
 })
 export class OrderProductsComponent implements OnChanges {
 
+  URLAPI = environment.urlStatic;
   @Input() products: Product[] = [];
   @Output() productsSelected = new EventEmitter<ProductOrder[]>();
 


### PR DESCRIPTION
Uncomment the 'Cancelada' chip that was dormant and add CSS to dim the card and strike through its content when dayOrder.status is false.