### PR TITLE
feat: botón eliminar pedidos de productos y fix filtro pendientes

### DIFF
--- a/src/app/components/administration/product/product.component.css
+++ b/src/app/components/administration/product/product.component.css
@@ -166,3 +166,11 @@ mat-form-field {
     font-size: 12px;
     padding: 0 8px;
 }
+
+.order-delete-btn {
+    height: 32px;
+    line-height: 32px;
+    font-size: 12px;
+    padding: 0 8px;
+    min-width: 36px;
+}

--- a/src/app/components/administration/product/product.component.html
+++ b/src/app/components/administration/product/product.component.html
@@ -68,9 +68,10 @@
 
         <colgroup>
           <col style="width:5%"/>
-          <col style="width:15%"/>
-          <col style="width:20%"/>
-          <col style="width:60%"/>
+          <col style="width:13%"/>
+          <col style="width:18%"/>
+          <col style="width:56%"/>
+          <col style="width:8%"/>
         </colgroup>
 
         <ng-container matColumnDef="id">
@@ -108,11 +109,20 @@
                 </button>
               </ng-container>
               <ng-container *ngIf="p.status === 'entregado'">
-                <button mat-stroked-button class="item-deliver-btn" (click)="onOrderItemStatusChange(r, p, 'pendiente')" matTooltip="Volver a pendiente">
+                <button mat-stroked-button class="item-deliver-btn" (click)="onOrderItemStatusChange(r, p, 'pending')" matTooltip="Volver a pendiente">
                   <mat-icon>undo</mat-icon>
                 </button>
               </ng-container>
             </div>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef style="text-align:center"> Acciones </th>
+          <td mat-cell *matCellDef="let r" style="text-align:center">
+            <button mat-stroked-button class="order-delete-btn" (click)="onClickDeleteOrder(r)" matTooltip="Eliminar pedido">
+              <mat-icon>delete</mat-icon>
+            </button>
           </td>
         </ng-container>
 

--- a/src/app/components/administration/product/product.component.ts
+++ b/src/app/components/administration/product/product.component.ts
@@ -37,7 +37,7 @@ export class ProductComponent implements OnInit {
   // ── Pedidos ────────────────────────────────────────────────────────────────
   date: Date | null = null;
   orderRows: ProductOrder[] = [];
-  displayedOrderColumns: string[] = ['id', 'date', 'client', 'products'];
+  displayedOrderColumns: string[] = ['id', 'date', 'client', 'products', 'actions'];
   ordersDataSource: MatTableDataSource<ProductOrder>;
   showOrders: boolean = false;
 
@@ -46,12 +46,12 @@ export class ProductComponent implements OnInit {
 
   statusOptions: StatusOption[] = [
     { value: 'all',       label: 'Todos' },
-    { value: 'pendiente', label: 'Pendientes' },
+    { value: 'pending',   label: 'Pendientes' },
     { value: 'entregado', label: 'Entregados' },
   ];
 
   statusLabels: Record<ProductOrderStatus, string> = {
-    pendiente: 'Pendiente',
+    pending:   'Pendiente',
     entregado: 'Entregado',
   };
 
@@ -122,8 +122,10 @@ export class ProductComponent implements OnInit {
 
   applyFilters() {
     let filtered = this.orderRows;
-    if (this.selectedStatus !== 'all') {
-      filtered = filtered.filter(r => r.products.every(p => p.status === this.selectedStatus));
+    if (this.selectedStatus === 'pending') {
+      filtered = filtered.filter(r => r.products.some(p => p.status === 'pending'));
+    } else if (this.selectedStatus === 'entregado') {
+      filtered = filtered.filter(r => r.products.every(p => p.status === 'entregado'));
     }
     if (this.clientSearch.trim()) {
       const q = this.clientSearch.trim().toLowerCase();
@@ -138,6 +140,12 @@ export class ProductComponent implements OnInit {
 
   onClientSearchChange() {
     this.applyFilters();
+  }
+
+  async onClickDeleteOrder(order: ProductOrder) {
+    if (await this.dialogService.openConfirmDialog('Está a punto de eliminar el pedido. ¿Está seguro?') === true) {
+      this.productService.deleteProductOrder(order.id).subscribe(() => this.loadProductOrders());
+    }
   }
 
   onOrderItemStatusChange(order: ProductOrder, item: ProductOrderItem, newStatus: ProductOrderStatus) {

--- a/src/app/components/clients/order-product/order-product.component.ts
+++ b/src/app/components/clients/order-product/order-product.component.ts
@@ -149,7 +149,7 @@ export class OrderProductComponent implements OnInit {
         productTitle: item.product.title,
         productCategoryTitle: this.getCategoryName(item.product.productCategoryId),
         cant: item.cant,
-        status: 'pendiente'
+        status: 'pending'
       }))
     };
     this.productService.addProductOrder(order).subscribe();

--- a/src/app/shared/routes/api.routes.ts
+++ b/src/app/shared/routes/api.routes.ts
@@ -132,5 +132,6 @@ export const API_ROUTES = {
         GETPRODUCTORDERSBYDATE: `${ENV.urlApi}/${INTERNAL_ROUTES.PRODUCT_ORDER}/getProductOrdersByDate`,
         ADDPRODUCTORDER: `${ENV.urlApi}/${INTERNAL_ROUTES.PRODUCT_ORDER}/addProductOrder`,
         UPDATEPRODUCTORDERITEMSTATUS: `${ENV.urlApi}/${INTERNAL_ROUTES.PRODUCT_ORDER}/updateOrderItemStatus`,
+        DELETEPRODUCTORDER: `${ENV.urlApi}/${INTERNAL_ROUTES.PRODUCT_ORDER}/deleteProductOrder`,
     },
 }

--- a/src/app/shared/services/product.service.ts
+++ b/src/app/shared/services/product.service.ts
@@ -11,7 +11,7 @@ import { EditProductResponse } from '../dto/product/EditProductResponse';
 import { GetProductResponse } from '../dto/product/GetProductResponse';
 import * as ROUTES from '../routes/index.routes';
 
-export type ProductOrderStatus = 'pendiente' | 'entregado';
+export type ProductOrderStatus = 'pending' | 'entregado';
 
 export interface ProductOrderItem {
   id?: number;
@@ -121,6 +121,13 @@ export class ProductService {
   addProductOrder(order: Omit<ProductOrder, 'id'>): Observable<ProductOrder> {
     return this.http.post<any>(ROUTES.API_ROUTES.PRODUCT_ORDER.ADDPRODUCTORDER, JSON.stringify(order), this.OPTION).pipe(
       map(res => res.productOrder as ProductOrder)
+    );
+  }
+
+  deleteProductOrder(id: number): Observable<void> {
+    const params = new HttpParams().set('idProductOrder', id.toString());
+    return this.http.delete<any>(ROUTES.API_ROUTES.PRODUCT_ORDER.DELETEPRODUCTORDER, { params }).pipe(
+      map(() => undefined)
     );
   }
 }


### PR DESCRIPTION
- Columna Acciones con botón eliminar en tabla de pedidos (soft delete con confirmación)
- Filtro Pendientes corregido: usa some() en lugar de every()
- Status de items normalizado a 'pending' (retrocompat con 'pendiente' y '' en DB)
- Nuevo endpoint DELETEPRODUCTORDER en rutas y servicio